### PR TITLE
Use absolute path in .env

### DIFF
--- a/public/packages/concrete_cms_docs/controllers/api_documentation.php
+++ b/public/packages/concrete_cms_docs/controllers/api_documentation.php
@@ -32,7 +32,7 @@ class ApiDocumentation
 
         $latestVersion = '0.0.0'; // start at zero
 
-        foreach (new \DirectoryIterator('../' . getenv('PATH_SITE_DOCUMENTATION_API')) as $dir) {
+        foreach (new \DirectoryIterator(getenv('PATH_SITE_DOCUMENTATION_API')) as $dir) {
             if ($dir->isDot()) {
                 continue;               // ignore '..' and '.'
             }


### PR DESCRIPTION
Differences between directory structure on local machine and server make this not a good idea. Just use absolute path in .env